### PR TITLE
Get protected root path once

### DIFF
--- a/src/EPiServer.Marketing.KPI/Common/Helpers/KpiHelper.cs
+++ b/src/EPiServer.Marketing.KPI/Common/Helpers/KpiHelper.cs
@@ -14,6 +14,19 @@ namespace EPiServer.Marketing.KPI.Common.Helpers
     [ServiceConfiguration(ServiceType = typeof(IKpiHelper), Lifecycle = ServiceInstanceScope.Singleton)]
     internal class KpiHelper : IKpiHelper
     {
+        private readonly string ProtectedRootPath;
+
+        public KpiHelper()
+        {
+            ProtectedRootPath = Shell.Paths.ProtectedRootPath;
+        }
+        
+        //Internal constructor for unit testing, as Shell can't be mocked.
+        internal KpiHelper(string protectedPath)
+        {
+            ProtectedRootPath = protectedPath;
+        }
+
         /// <summary>
         /// Evaluates current URL to determine if page is in a system folder context (e.g Edit, or Preview)
         /// </summary>
@@ -21,7 +34,7 @@ namespace EPiServer.Marketing.KPI.Common.Helpers
         public virtual bool IsInSystemFolder()
         {
             return HttpContext.Current == null ||
-                   HttpContext.Current.Request.RawUrl.IndexOf(Shell.Paths.ProtectedRootPath, StringComparison.OrdinalIgnoreCase) >= 0;
+                   HttpContext.Current.Request.RawUrl.IndexOf(ProtectedRootPath, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         public string GetUrl(ContentReference contentReference)

--- a/test/EPiServer.Marketing.KPI.Test/Common/KpiHelperTests.cs
+++ b/test/EPiServer.Marketing.KPI.Test/Common/KpiHelperTests.cs
@@ -16,7 +16,7 @@ namespace EPiServer.Marketing.KPI.Test.Common
     {
         private IKpiHelper GetUnitUnderTest()
         {            
-            return new KpiHelper();
+            return new KpiHelper("~/protected/");
         }        
 
         [Fact]

--- a/test/EPiServer.Marketing.Testing.Test/Web/KpiStoreTests.cs
+++ b/test/EPiServer.Marketing.Testing.Test/Web/KpiStoreTests.cs
@@ -1,6 +1,7 @@
 ﻿using EPiServer.Framework.Localization;
 using EPiServer.Logging;
 using EPiServer.Marketing.KPI.Common;
+using EPiServer.Marketing.KPI.Common.Helpers;
 using EPiServer.Marketing.Testing.Test.Fakes;
 using EPiServer.Marketing.Testing.Web.Controllers;
 using EPiServer.Marketing.Testing.Web.Models;
@@ -97,7 +98,8 @@ namespace EPiServer.Marketing.Testing.Test.Web
             kpis.Add(dict2);
 
             _kpiWebRepoMock.Setup(call => call.DeserializeJsonKpiFormCollection(It.IsAny<string>())).Returns(kpis);
-            var sticky = new Mock<StickySiteKpi>();
+
+            var sticky = new Mock<StickySiteKpi>(new Mock<IServiceLocator>().Object, new KpiHelper(""));
             _kpiWebRepoMock.Setup(call => call.ActivateKpiInstance(It.IsAny<Dictionary<string, string>>())).Returns(sticky.Object);
 
             var retResult = testClass.Put("KpiFormData", "") as RestResult;
@@ -132,7 +134,7 @@ namespace EPiServer.Marketing.Testing.Test.Web
             kpis.Add(dict2);
 
             _kpiWebRepoMock.Setup(call => call.DeserializeJsonKpiFormCollection(It.IsAny<string>())).Returns(kpis);
-            var sticky = new Mock<StickySiteKpi>();
+            var sticky = new Mock<StickySiteKpi>(new Mock<IServiceLocator>().Object, new KpiHelper(""));
             _kpiWebRepoMock.Setup(call => call.ActivateKpiInstance(It.IsAny<Dictionary<string, string>>())).Returns(sticky.Object);
 
             var retResult = testClass.Put("KpiFormData", "") as RestResult;


### PR DESCRIPTION
As Shell.Paths.ProtectedRootPath uses
ServiceLocator.Current.GetInstance internally
calling it every time will be expensive as
dependency will have to be built. As the property
is readonly, we only need to get it once for the life time of the app